### PR TITLE
Cloud 3298

### DIFF
--- a/cloudformation/template.yaml
+++ b/cloudformation/template.yaml
@@ -631,6 +631,8 @@ Resources:
       Variables:
         DevPortalFunctionName: !Ref DevPortalLambdaFunction
 
+# ACL's are disabled in favour of policies see below
+# https://aws.amazon.com/blogs/aws/heads-up-amazon-s3-security-changes-are-coming-in-april-of-2023/
   DevPortalSiteS3Bucket:
     Type: AWS::S3::Bucket
     Properties:
@@ -640,6 +642,18 @@ Resources:
         BlockPublicPolicy: !If [ NotDevelopmentMode, 'true', 'false' ]
         IgnorePublicAcls: !If [ NotDevelopmentMode, 'true', 'false' ]
         RestrictPublicBuckets: !If [ NotDevelopmentMode, 'true', 'false' ]
+
+  DevPortalSiteS3BucketPolicyDev:
+    Type: 'AWS::S3::BucketPolicy'
+    Condition: 'DevelopmentMode'
+    Properties:
+      Bucket: !Ref DevPortalSiteS3Bucket
+      PolicyDocument:
+        Statement:
+          - Action: 's3:GetObject'
+            Effect: Allow
+            Resource: !Sub 'arn:aws:s3:::${DevPortalSiteS3Bucket}/*'
+            Principal: "*"
 
   DevPortalSiteS3BucketPolicy:
     Type: 'AWS::S3::BucketPolicy'

--- a/lambdas/static-asset-uploader/index.js
+++ b/lambdas/static-asset-uploader/index.js
@@ -175,9 +175,9 @@ class State {
     }
     const options = {}
 
-    if (this.event.ResourceProperties.DevelopmentMode === 'true') {
-      params.ACL = 'public-read'
-    }
+    // if (this.event.ResourceProperties.DevelopmentMode === 'true') {
+    //   params.ACL = 'public-read'
+    // }
 
     // FIXME: Marketplace support is currently broken
     // const suffix = this.event.ResourceProperties.MarketplaceSuffix
@@ -209,9 +209,9 @@ class State {
       }
       const options = {}
 
-      if (this.event.ResourceProperties.DevelopmentMode === 'true') {
-        params.ACL = 'public-read'
-      }
+      // if (this.event.ResourceProperties.DevelopmentMode === 'true') {
+      //   params.ACL = 'public-read'
+      // }
 
       // body just pollutes logs and takes up space
       console.log('uploading to s3', {


### PR DESCRIPTION
*Issue 
AWS breaking changes update - see https://aws.amazon.com/blogs/aws/heads-up-amazon-s3-security-changes-are-coming-in-april-of-2023/

*Description of changes:*

Created a new policy for dev that allows s3 access and takes the place of the recently disabled ACL ability 

I have left the old lambda code commented in case of future requirement.

Please note that this should not affect current Production builds as the the policy for Production that is generated only allows Cloudfront access.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
